### PR TITLE
refactor view director to pivot to useContext

### DIFF
--- a/utils/ViewDirector.js
+++ b/utils/ViewDirector.js
@@ -12,6 +12,7 @@ const ViewDirectorBasedOnUserAuthStatus = ({ component: Component, pageProps }) 
     user, userLoading, updateUser,
   } = useAuth();
   const [searchInput, setSearchInput] = useState('');
+  // const [searchReturn, setSearchReturn] = useState({});
 
   // if user state is null, then show loader
   if (userLoading) {


### PR DESCRIPTION
initially was trying to access debounce data through parent child relationships. Changing that approach so removing useState so that useContext can be used.